### PR TITLE
Add kustomization manifest files

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etos-suite-starter
+  labels:
+    app.kubernetes.io/name: etos-suite-starter
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-starter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: etos-suite-starter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etos-suite-starter
+    spec:
+      serviceAccountName: etos-suite-starter
+      containers:
+        - name: etos-suite-starter
+          image: "registry.nordix.org/eiffel/etos-suite-starter:2.0.1"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+          - configMapRef:
+              name: etos-suite-starter

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role.yaml
+  - service-account.yaml
+  - rolebinding.yaml
+  - deployment.yaml
+  - suite-runner-service-account.yaml
+
+
+# By generating the configmap it will get a unique name on each apply
+# this name is also set on the deployment. This means that the pods
+# will restart with the new configmap when changes are made. Making
+# it so we do not have to do rollout restart every time.
+configMapGenerator:
+  - name: etos-suite-starter
+    literals:
+      - SUITE_RUNNER=registry.nordix.org/eiffel/etos-suite-runner:3.1.0
+      - LOG_LISTENER=registry.nordix.org/eiffel/etos-log-listener:3.1.0

--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: etos-suite-starter
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-starter
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: etos-suite-starter:sa:job-creator
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - update
+  - watch
+  - list
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update

--- a/manifests/base/rolebinding.yaml
+++ b/manifests/base/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: etos-suite-starter
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-starter
+  name: etos-suite-starter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etos-suite-starter:sa:job-creator
+subjects:
+- kind: ServiceAccount
+  name: etos-suite-starter

--- a/manifests/base/service-account.yaml
+++ b/manifests/base/service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etos-suite-starter
+  labels:
+    app.kubernetes.io/name: etos-suite-starter
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-starter

--- a/manifests/base/suite-runner-service-account.yaml
+++ b/manifests/base/suite-runner-service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etos-sa
+  labels:
+    app.kubernetes.io/name: etos-suite-runner
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-runner


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#188

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add manifest files to suite starter

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could keep all manifest files in the ETOS repository, but I think letting each component decide on its own versions and having the ETOS repository set the release versions is the correct way.

### Benefits
<!-- What benefits will be realized by the change? -->
Kustomize is easier to handle and built into kubectl

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None really

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
