### PR TITLE
Add a CI workflow for ETOS suite starter

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,45 @@
+name: Build and push
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build app image
+      run: docker build . --tag image
+
+    - name: Log into registry
+      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+
+    - name: Push app image
+      id: image
+      run: |
+        IMAGE_ID=registry.nordix.org/eiffel/${{ github.repository }}
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "main" ] && VERSION=$(echo ${{ github.sha }} | cut -c1-8)
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker tag image $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION
+        echo $IMAGE_ID:$VERSION
+        echo "::set-output name=version::$VERSION"
+    - name: Update manifests
+      uses: fjogeleit/yaml-update-action@main
+      with:
+        valueFile: 'manifests/base/deployment.yaml'
+        propertyPath: 'spec.template.spec.containers[0].image'
+        value: registry.nordix.org/eiffel/etos-suite-starter:${{ steps.image.outputs.version }}
+        commitChange: true
+        message: Updating manifest image to version ${{ steps.image.outputs.version }}


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#197

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This workflow will run when a PR is merged, it will build the docker image with the current SHA as tag and push it to the registry.
After the image has been pushed it will update the image version in the manifests and push them to main.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None that I can think of

### Benefits
<!-- What benefits will be realized by the change? -->
This will allow us to have fresh builds of the suite builder every time we merge to main, this will also allow us to track the main branch in our gitops tools.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We will build a lot more containers. But before we created a release often where we built a container.
This style probably won't work with the ESR and LogListener containers though, so we need to look into how to build and release them. I think we can solve it by defining the configmap (that we create in the kustomization file in this repository) in the suite runner repository and link it into the suite starter instead.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
