### PR TITLE
Prevent validation error if observability configmap not set

### DIFF
--- a/src/suite_starter/suite_starter.py
+++ b/src/suite_starter/suite_starter.py
@@ -109,6 +109,22 @@ class SuiteStarter:  # pylint:disable=too-many-instance-attributes
         env = ",".join(f"{k}={v}" for k, v in carrier.items())
         return env
 
+    @classmethod
+    def remove_empty_configmaps(cls, data):
+        """Iterate the ESR configuration dict recursively and remove empty configmaps."""
+        element_to_remove = {"configMapRef": {"name": "None"}}
+        if isinstance(data, dict):
+            for key, value in list(data.items()):
+                if value == element_to_remove:
+                    del data[key]
+                else:
+                    cls.remove_empty_configmaps(value)
+        elif isinstance(data, list):
+            while element_to_remove in data:
+                data.remove(element_to_remove)
+            for item in data:
+                cls.remove_empty_configmaps(item)
+
     def suite_runner_callback(self, event, _):
         """Start a suite runner on a TERCC event.
 
@@ -144,6 +160,9 @@ class SuiteStarter:  # pylint:disable=too-many-instance-attributes
             body = job.load_yaml(
                 self.suite_runner_template.format(**data, **self.etos.config.get("configuration"))
             )
+            # needed to handle cases when some configmaps aren't set, such as etos_observability_configmap:
+            self.remove_empty_configmaps(body)
+
             LOGGER.info("Starting new executor: %r", job_name)
             job.create_job(body)
             LOGGER.info("ESR successfully launched.")

--- a/src/suite_starter/suite_starter.py
+++ b/src/suite_starter/suite_starter.py
@@ -160,7 +160,7 @@ class SuiteStarter:  # pylint:disable=too-many-instance-attributes
             body = job.load_yaml(
                 self.suite_runner_template.format(**data, **self.etos.config.get("configuration"))
             )
-            # needed to handle cases when some configmaps aren't set, such as etos_observability_configmap:
+            # Handle cases when some configmaps aren't set (e. g. etos_observability_configmap):
             self.remove_empty_configmaps(body)
 
             LOGGER.info("Starting new executor: %r", job_name)


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/232

### Description of the Change

This change removes empty configmap references from the suite-runner job config before creating a suite-runner job.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com