### PR TITLE
Allow suite runners read testrun objects

### DIFF
--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -53,3 +53,30 @@ rules:
   - create
   - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: testrun-reader
+  labels:
+    app.kubernetes.io/name: etos-testrun-reader
+    app.kubernetes.io/part-of: etos
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+rules:
+- apiGroups:
+  - "etos.eiffel-community.github.io"
+  resources:
+  - testruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "etos.eiffel-community.github.io"
+  resources:
+  - testruns/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/base/rolebinding.yaml
+++ b/manifests/base/rolebinding.yaml
@@ -13,3 +13,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: etos-suite-starter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: etos-suite-runner
+    app.kubernetes.io/part-of: etos
+    app.kubernetes.io/component: suite-runner
+  name: etos-sa-testrun-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: testrun-reader
+subjects:
+- kind: ServiceAccount
+  name: etos-sa


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/300

### Description of the Change

This change adds a role with a rolebinding to allow suite runners read testrun custom objects.  This is needed to avoid passing TERCC to suite runners via environment variable. The variables have a size limit and larger TERCCs cannot fit into it.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com