### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,6 +7,10 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,13 +16,17 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-suite-starter
+        IMAGE_ID=ghcr.io/eiffel-community/etos-suite-starter
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -40,7 +44,7 @@ jobs:
       with:
         valueFile: 'manifests/base/deployment.yaml'
         propertyPath: 'spec.template.spec.containers[0].image'
-        value: registry.nordix.org/eiffel/etos-suite-starter:${{ steps.image.outputs.version }}
+        value: ghcr.io/eiffel-community/etos-suite-starter:${{ steps.image.outputs.version }}
         branch: main
         commitChange: true
         message: Updating manifest image to version ${{ steps.image.outputs.version }}

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: etos-suite-starter
       containers:
         - name: etos-suite-starter
-          image: registry.nordix.org/eiffel/etos-suite-starter:28ac79b9
+          image: ghcr.io/eiffel-community/etos-suite-starter:28ac79b9
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: suite-runner-template


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This pull request changes all docker image references from `nordix.org/eiffel` to `ghcr.io/eiffel-community`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com