### PR TITLE
Remove in-service telemetry signals envrionment logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "etos_lib==4.5.0",
+    "etos_lib==5.1.2",
     "opentelemetry-api~=1.21",
     "opentelemetry-exporter-otlp~=1.21",
     "opentelemetry-sdk~=1.21",

--- a/src/suite_starter/__init__.py
+++ b/src/suite_starter/__init__.py
@@ -21,7 +21,6 @@ from etos_lib.logging.logger import setup_logging
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import (
-    DEPLOYMENT_ENVIRONMENT,
     SERVICE_NAME,
     SERVICE_VERSION,
     OTELResourceDetector,
@@ -43,12 +42,11 @@ except PackageNotFoundError:
 
 BASE = os.path.dirname(os.path.abspath(__file__))
 DEV = os.getenv("DEV", "false").lower() == "true"
-ENVIRONMENT = "development" if DEV else "production"
+
 OTEL_RESOURCE = Resource.create(
     {
         SERVICE_NAME: "etos-suite-starter",
         SERVICE_VERSION: VERSION,
-        DEPLOYMENT_ENVIRONMENT: ENVIRONMENT,
     }
 )
 
@@ -62,6 +60,6 @@ if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
     PROCESSOR = BatchSpanProcessor(EXPORTER)
     PROVIDER.add_span_processor(PROCESSOR)
     trace.set_tracer_provider(PROVIDER)
-    setup_logging("ETOS Suite Starter", VERSION, ENVIRONMENT, OTEL_RESOURCE)
+    setup_logging("ETOS Suite Starter", VERSION, OTEL_RESOURCE)
 else:
-    setup_logging("ETOS Suite Starter", VERSION, ENVIRONMENT)
+    setup_logging("ETOS Suite Starter", VERSION)


### PR DESCRIPTION
Since the logic to figure out in what environment the service is running
is very limited, we remove the logic and let it be handled better
somewhere outside of the service.

### Description of the Change
Since the logic to figure out in what environment the service is running
is very limited, we remove the logic and let it be handled better
somewhere outside of the service.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Fredrik Fristedt <<fredrik.fristedt@axis.com>>
