### PR TITLE
Fix otel logging setup bug

### DIFF
--- a/src/suite_starter/__init__.py
+++ b/src/suite_starter/__init__.py
@@ -60,6 +60,6 @@ if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
     PROCESSOR = BatchSpanProcessor(EXPORTER)
     PROVIDER.add_span_processor(PROCESSOR)
     trace.set_tracer_provider(PROVIDER)
-    setup_logging("ETOS Suite Starter", VERSION, OTEL_RESOURCE)
+    setup_logging("ETOS Suite Starter", VERSION, otel_resource=OTEL_RESOURCE)
 else:
     setup_logging("ETOS Suite Starter", VERSION)


### PR DESCRIPTION
### Description of the Change
Since we recently changed how setup_logging is initialized we now need
to pass the open telemetry as a named parameter.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <fredrik.fristedt@axis.com>>
