### PR TITLE
Update GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Install Tox
@@ -37,10 +37,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Run hadolint for Suite starter
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile
 
@@ -52,10 +52,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Build Suite starter image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/update-etos.yaml
+++ b/.github/workflows/update-etos.yaml
@@ -39,7 +39,7 @@ jobs:
         } >> "$GITHUB_ENV"
     - name: Generate a token
       id: generate-token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         owner: ${{ env.REPOSITORY_OWNER }}
         repositories: ${{ env.ETOS_REPOSITORY }}
@@ -50,7 +50,7 @@ jobs:
         repository: ${{ env.REPOSITORY_OWNER }}/${{ env.ETOS_REPOSITORY }}
         token: ${{ steps.generate-token.outputs.token }}
     - name: Update manifests
-      uses: fjogeleit/yaml-update-action@main
+      uses: fjogeleit/yaml-update-action@v0.16.1
       with:
         commitChange: false
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/595

### Description of the Change

Update 3 workflow files: checkout v2→v6, setup-python v2→v6, docker/login-action v3→v4, docker/build-push-action v2→v7, hadolint/hadolint-action master→v3.3.0, create-github-app-token v2→v3, and fjogeleit/yaml-update-action main→v0.16.1.

### Alternate Designs

_No response_

### Possible Drawbacks

Note: `fjogeleit/yaml-update-action` is pinned to v0.16.1 (still node20) as no node24-compatible release exists yet.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com